### PR TITLE
Restore Linux/BSD download options

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,8 +15,8 @@ The latest version is {{version}}, released {{site.data.gpodder.date}}. Read the
     <small>You also need to install [32-bit Python {{site.data.windows.pythonVersion}}][win-python] and [PyGTK {{site.data.windows.pygtkVersion}}][win-gtk]</small>
 -   macOS: [gPodder {{site.data.macos.version}}][mac]<br>
     <small>Already includes Python and PyGTK</small>
--   Linux/BSD: Install via the package manager<br>
-    <small>Available in most distributions (Debian, Ubuntu, Fedora, ...)</small>
+-   Linux/BSD: [Ubuntu PPA][], [AppImage][], or [run from Git][]<br>
+    <small>Also available in Debian, Ubuntu, Fedora, FreeBSD Ports, ...</small>
 -   Source code: [github.com/gpodder/gpodder](https://github.com/gpodder/gpodder)
 
 ### Get help
@@ -28,3 +28,6 @@ Ask on the [mailing list](http://www.freelists.org/list/gpodder), report problem
 [win-python]: https://www.python.org/ftp/python/{{site.data.windows.pythonVersion}}{{site.data.windows.pythonPatch}}/python-{{site.data.windows.pythonVersion}}{{site.data.windows.pythonPatch}}.msi
 [win-gtk]: http://ftp.gnome.org/pub/GNOME/binaries/win32/pygtk/{{site.data.windows.pygtkVersion}}/pygtk-all-in-one-{{site.data.windows.pygtkVersion}}{{site.data.windows.pygtkPatch}}.win32-py{{site.data.windows.pythonVersion}}.msi
 [mac]: https://sourceforge.net/projects/gpodder/files/macosx/gPodder-{{site.data.macos.version}}{{site.data.macos.patch}}.zip/download
+[Ubuntu PPA]: https://launchpad.net/~thp/+archive/ubuntu/gpodder
+[AppImage]: https://bintray.com/probono/AppImages/gPodder
+[run from Git]: https://github.com/gpodder/gpodder/wiki/Run-from-Git


### PR DESCRIPTION
Originally I thought this section was consciously changed and left it alone, but seeing recent changes suggesting that this website was created from an earlier version of gpodder.org, I have restored the additional Linux links.

Based on the Internet Archive Wayback Machine 2017-05-17 capture of the website.