### PR TITLE
Move podcast wikipedia link to body from subtitle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
     <img alt="" src="{{page.logo}}" style="height: 80px; float: right;">
     <h2>{{page.title}}
       {% if page.subtitle %}
-      <span style="font-size: 10pt; color: #aaa;">// {{page.subtitle | markdownify  | remove: '<p>' | remove: '</p>'}}</span>
+      <span style="font-size: 10pt; color: #aaa;">// {{page.subtitle}}</span>
       {% endif %}
     </h2>
     

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 title: gPodder
-subtitle: Media aggregator and [podcast](https://en.wikipedia.org/wiki/Podcast) client
+subtitle: Media aggregator and podcast client
 logo: gpodder.png
 ---
 
@@ -16,7 +16,7 @@ ul li {
 }
 </style>
 
-gPodder is a simple, open source podcast client written in Python using GTK+. In development since 2005 with a proven, mature codebase.
+gPodder is a simple, open source [podcast](https://en.wikipedia.org/wiki/Podcast) client written in Python using GTK+. In development since 2005 with a proven, mature codebase.
 
 {% assign version = site.data.gpodder.version %}
 The latest version is {{version}}, released {{site.data.gpodder.date}}. Read the [release notes](http://blog.gpodder.org/).


### PR DESCRIPTION
The hyperlink in the small-text subtitle on the main page always struck me as odd.  The same word occurs in the first paragraph of normal text, so this change moves the link to there.

Since it is then no longer needed, support for markdown within subtitles was also removed.