### PR TITLE
Remove dated section with dead link about porting gPodder to Android

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -5,7 +5,3 @@ title: Android
 ### Third party apps
 
 * [List of Android Clients supporting gPodder.net](http://gpoddernet.readthedocs.io/en/latest/user/clients.html#android)
-
-### gPodder on Android
-
-[thp](https://github.com/thp) has done some work on getting PySide to run on Android, which could potentially allow the QML UI of gPodder to run on Android: [PySide on Android](http://thp.io/2011/pyside-android/). Please note that this is not for the faint of the heart, and will require rooting of your Android device.


### PR DESCRIPTION
Remove dated section with dead link about porting gPodder to Android.  Happy to have this handled some other way as well.  This was just the clearest solution I saw.