### PR TITLE
Link to Flatpak

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ The latest version is <span id="latest-version">{{version}}</span>, released <sp
     <small>Already includes Python 3, Gtk 3</small>
 -   macOS: [gPodder {{site.data.macos.version}}][mac]<br>
     <small>Already includes Python 3, Gtk 3</small>
--   Linux/BSD: In your distro, or [run from Git](docs/run-from-git.md)<br>
+-   Linux/BSD: In your distro, as [Flatpak](https://flathub.org/apps/details/org.gpodder.gpodder) or [run from Git](docs/run-from-git.md)<br>
     <small>Available in Debian, Ubuntu, Fedora, FreeBSD Ports, ...</small>
 -   Sailfish OS: from [OpenRepos](https://openrepos.net/content/keeperofthekeys/gpodder)<br>
     <small>a flavor of gPodder for mobiles running Sailfish OS 1.0.4.20 or later.</small>


### PR DESCRIPTION
Looks like somebody is now maintaining a relatively recent version of gPodder on Flathub:

https://github.com/flathub/org.gpodder.gpodder

https://flathub.org/apps/details/org.gpodder.gpodder

(note that the repo already contains 3.10.15, not sure when this will show up on flathub)