### PR TITLE
Update the outdated Youtube documentation.

### DIFF
--- a/docs/extensions/youtubedl.md
+++ b/docs/extensions/youtubedl.md
@@ -40,7 +40,7 @@ about the youtube-dl format specification and for more examples.
 
 Youtube-dl will load the page for your subscription (channel, playlist, ...) and find all
 videos there. This way you will get all episodes, not only the last 15 like in Youtube's own
-RSS feed. You don't need a Youtube API key for this.
+RSS feed.
 
 The major drawback is that youtube-dl is **very slow** to get this information because
 it has to download and parse each video page.

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -2,37 +2,46 @@
 title: YouTube
 ---
 
-These are instructions to subscribe to user channels in YouTube - post June 2015.
+These are instructions to subscribe to user channels in YouTube - 3.10.20 and later.
 
-Why do I need to do this?
--------------------------
 
-There is no more transparent relation between user name and RSS feed. gPodder needs to use the google YouTube API to convert the user name (e.g. *Pentadact*) to an RSS feed (e.g. <https://www.youtube.com/feeds/videos.xml?channel_id=UCQ-twzO6v-PBgckhkrXVaDQ>). To do so, it must provide an API key to google to be granted access to the API. There are quotas in place for each key, so the gPodder devs can't simply give a key for everyone to use. Everyone has to get their own.
+Subscribe to channels
+---------------------
 
-How do I do it ?
+The URL for channel or video pages can be used to subscribe to a channel.
+
+
+Built-in support
 ----------------
 
-We will follow <https://developers.google.com/youtube/v3/getting-started?hl=fr>
+The built-in YouTube support is limited to the 15 most recent videos posted on the channel, and can not download DRM or age-restricted videos. Live streams can be streamed while live, but can only be downloaded after they have ended, usually several hours later. All downloadable videos can be streamed.
 
-1. You need a google account (your gmail address).
-2. Go to <https://console.developers.google.com/>
-  *  Login with your google account.
-3. Click the button *Create a project*
-  *  Name it whatever you want (e.g. gPodderAPI)
-4. Go to *API & auth* &gt; *APIs*
-  *  Search for / click on YouTube Data API
-  *  Click *Enable*
-5. Go to *API & auth* &gt; *Credentials*
-  *  In the *Public API access* section, click on the *create new key* button
-  *  Choose *Browser key*
-  *  Don't enter anything in the HTTP referers text area
-  *  Click the *Create* button
-6. Your API key appears.
-  *  Copy the long string of letters and numbers
-7. Open gPodder 3.8.4 or later
-  *  Activate the *Extras* > *Update YouTube subscriptions* menu item
-  *  Click YES to enter your API key
-  *  Paste your API key in the *Youtube api key (v3)* field.
-  *  Close the settings window.
-  *  Activate the *Extras* > *Update YouTube subscriptions* menu item again.
-8. You're done
+Changes to YouTube's API can prevent channel updates or episode downloads until fixed and a new gPodder release is made available. The [YouTube-DL extension](https://gpodder.github.io/docs/extensions/youtubedl.html) can often be used to allow continued access to YouTube while the built-in support is not working.
+
+
+YouTube-DL extension
+--------------------
+
+YouTube-DL can be used to download higher resolution videos as well as DRM and age-restricted content.
+
+The `extensions.youtube-dl.manage_channel` setting uses YouTube-DL to update channels, enabling access to all episodes on the channel, bypassing the 15 episode limit of the built-in support. It does however take significantly longer to update channels using this feature.
+
+The `extensions.youtube-dl.manage_downloads` setting uses YouTube-DL to download all episodes. In the future, it will be possible to stream with this enabled and a video player with YouTube-DL such as MPV. But for now, this setting must be disabled to stream episodes.
+
+When `extensions.youtube-dl.manage_downloads` is disabled, the right-click menu for episodes has a `Download with Youtube-DL` action. This allows episodes to still be streamed, but requires manual downloading of each episode if YouTube-DL formats are wanted.
+
+On Linux, YouTube-DL can be updated externally to fix issues that occur after YouTube API changes. On Windows, a newer GIT version (if available) can be downloaded from <https://ci.appveyor.com/project/elelay/gpodder/build/artifacts> to update the bundled copy of YouTube-DL. It is not yet possible to upgrade the bundled copy in the Mac bundle.
+
+More information about the YouTube-DL extension can be found at <https://gpodder.github.io/docs/extensions/youtubedl.html>.
+
+
+Formats
+-------
+
+The `Video` tab in `Preferences` has options to select the download and live streaming (HLS) formats. HLS formats are only available during a live stream, and streaming of non-livestream episodes always uses the download format.
+
+The built-in support is limited to MP4 360p (18) and MP4 720p (22) formats. It can also download the audio-only formats: M4A 128k (140), WEBM 50k (249), WEBM 70k (250), and WEBM 160k (251). They are not yet fully supported and must be added to the `youtube.preferred_fmt_ids` setting, separated by commas, and then choosing the custom formats option.
+
+The formats labelled with `youtube-dl` only work with YouTube-DL and fall-back to the above formats when built-in support is used. The `best` formats are also not yet supported and must be enabled like the above audio formats.
+
+WEBM formats fall-back to MP4 when a WEBM format is not available at the desired resolution.


### PR DESCRIPTION
It says 3.10.20 because subscribing to video pages requires gpodder/gpodder#1055. And some other details require latest git. Hopefully, I will get around to a release soon, but need to fix something before translators translate it.

@elelay Is the info about re-installing mac version to update youtube-dl correct?

Fixes gpodder/gpodder#1053.