### PR TITLE
Update the example podcasts OPML

### DIFF
--- a/directory/examples.opml
+++ b/directory/examples.opml
@@ -2,16 +2,37 @@
 <opml version="2.0">
   <head>
     <title>gPodder Getting Started Podcasts</title>
-    <dateCreated>Thu, 23 Oct 2014 10:09:11 +0200</dateCreated>
+    <dateCreated>Thu, 24 Mar 2022 18:53:47 +0100</dateCreated>
   </head>
   <body>
-    <outline text="Live Laugh Drink Beer is primarily a Craft Beer podcast will make your soul smile." title="Live Laugh Drink Beer" type="rss" xmlUrl="https://livelaughdrinkbeer.com/feed/podcast/"/>
-    <outline text="True stories, told live and without notes, to standing-room-only crowds worldwide." title="The Moth Podcast" type="rss" xmlUrl="http://feeds.themoth.org/themothpodcast"/>
-    <outline text="Science meets culture and information sounds like music." title="Radiolab from WNYC" type="rss" xmlUrl="http://feeds.wnyc.org/radiolab"/>
-    <outline text="Independent music from Austria." title="FM4 Soundpark" type="rss" xmlUrl="http://static.orf.at/fm4/podcast/soundpark.xml"/>
-    <outline text="Videos to inspire, intrigue and stir the imagination from some of the world's leading thinkers and doers." title="TEDTalks (video)" type="rss" xmlUrl="http://feeds.feedburner.com/tedtalks_video"/>
-    <outline text="The Verge covers the intersection of technology, science, art, and culture." title="The Verge on YouTube" type="rss" xmlUrl="http://www.youtube.com/rss/user/theverge/videos.rss"/>
-    <outline text="Hand picked by the real humans who work at Vimeo" title="Vimeo Staff Picks" type="rss" xmlUrl="http://vimeo.com/channels/staffpicks"/>
-    <outline text="Content posted by gu-mix on Soundcloud" title="gu-mix on Soundcloud" type="rss" xmlUrl="http://soundcloud.com/gu-mix"/>
+    <outline
+      title="The Moth Podcast"
+      text="True stories, told live and without notes, to standing-room-only crowds worldwide."
+      xmlUrl="http://feeds.themoth.org/themothpodcast"
+      type="rss"/>
+
+    <outline
+      title="Radiolab from WNYC"
+      text="Science meets culture and information sounds like music."
+      xmlUrl="http://feeds.wnyc.org/radiolab"
+      type="rss"/>
+
+    <outline
+      title="Back to Work"
+      text="Talk show with Merlin Mann and Dan Benjamin discussing productivity, communication, work, barriers, constraints, tools, and more."
+      xmlUrl="https://www.backtowork.limo/rss"
+      type="rss"/>
+
+    <outline
+      title="TEDTalks (video)"
+      text="Videos to inspire, intrigue and stir the imagination from some of the world's leading thinkers and doers."
+      xmlUrl="http://feeds.feedburner.com/tedtalks_video"
+      type="rss"/>
+
+    <outline
+      title="Technology Connections on YouTube"
+      text="Alec Watson discussing the history and evolution of various consumer technologies."
+      xmlUrl="https://www.youtube.com/channel/UCy0tKL1T7wFoYcxCe0xjN6Q"
+      type="rss"/>
   </body>
 </opml>


### PR DESCRIPTION
This hasn't been updated in ~ 8 years.

Removed entries:

- **Live Laugh Drink Beer** (site doesn't exist anymore)
- **FM4 Soundpark** (feed doesn't exist anymore)
- **The Verge on YouTube** (outdated YT link)
- **Vimeo Staff Picks** (feed and videos still work, but it doesn't have any text description, making it look weird)
- **gu-mix on Soundcloud** (Soundcloud support is broken atm)

Added entires:
 
- **Technology Connections** (new YouTube example)
- **Back to Work** (talk show)

Also formatted the OPML in a nicer way so it's easier to read.

This should make the first-time "select all example podcasts" work nicely again.